### PR TITLE
make wise m/r job read last ten minutes of data

### DIFF
--- a/Wise/src/main/java/co/cask/cdap/apps/wise/WiseApp.java
+++ b/Wise/src/main/java/co/cask/cdap/apps/wise/WiseApp.java
@@ -17,7 +17,6 @@ package co.cask.cdap.apps.wise;
 
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.data.stream.Stream;
-import co.cask.cdap.api.dataset.lib.KeyValueTable;
 
 /**
  * The Wise application performs analytics on Apache access logs.
@@ -33,8 +32,6 @@ public class WiseApp extends AbstractApplication {
     createDataset("pageViewStore", PageViewStore.class);
     // Custom Dataset to store bounce information for every web page
     createDataset("bounceCountStore", BounceCountStore.class);
-    // Utility Dataset used in the Map/Reduce job
-    createDataset("bounceCountsMapReduceLastRun", KeyValueTable.class);
     // Add the WiseFlow flow
     addFlow(new WiseFlow());
     // Add the WiseWorkflow workflow


### PR DESCRIPTION
This changes the Wise map/reduce job, not to use a dataset to keep track of when it last ran. Instead, because this mr is run every 10 minutes as part of a workflow schedule, it will always read the last ten minutes leading up to the logical start time of the workflow. 

I think this is nicer because it simplifies the app and it also illustrates the getLogicalStartTime() feature of the MR context.
