### PR TITLE
Wise: package name change in script

### DIFF
--- a/Wise/bin/app-manager.bat
+++ b/Wise/bin/app-manager.bat
@@ -19,7 +19,7 @@ REM ##
 REM #################################################################################
 
 REM Application Manager for managing application lifecycle for Wise application
-SET APP_JAR_PREFIX=Wise
+SET APP_JAR_PREFIX=cdap-wise
 
 SET APP_NAME=Wise
 SET FLOW_NAME=WiseFlow

--- a/Wise/bin/app-manager.sh
+++ b/Wise/bin/app-manager.sh
@@ -141,7 +141,7 @@ fi
 get_auth_token
 
 if [ "x$action" == "xdeploy" ]; then
-  jar_path=`ls $dir/../target/Wise-*.jar`
+  jar_path=`ls $dir/../target/cdap-wise-*.jar`
   deploy_action $app $jar_path $host
 elif [ "x$action" == "xrun" ]; then
   program_action $app "WiseWorkflow_BounceCountsMapReduce" "mapreduce" "start" $host


### PR DESCRIPTION
Changed the package name in the scripts to be consistent with changes in pom.xml done in this commit: 
https://github.com/caskdata/cdap-apps/commit/933f60b28e78ba90a79e07a957827d801a8b3b61

This was making script commands of readme to fail.
