### PR TITLE
CDAP-540: Update MovieRecommender to support CDAP 2.6.0 API.

### DIFF
--- a/MovieRecommender/src/main/java/co/cask/cdap/apps/movierecommender/MovieDictionaryService.java
+++ b/MovieRecommender/src/main/java/co/cask/cdap/apps/movierecommender/MovieDictionaryService.java
@@ -27,7 +27,6 @@ public class MovieDictionaryService extends AbstractService {
   protected void configure() {
     setName("MovieDictionaryService");
     setDescription("Service to store moviesStore information to dataset");
-    useDataset("movies");
     addHandler(new MovieDictionaryServiceHandler());
   }
 }


### PR DESCRIPTION
Removed call of useDataset method from MovieDictionaryService, to support CDAP 2.6.0 API; The movies dataset correctly provided in MovieDictionaryServiceHandler.
