### PR TITLE
Add oss sonatype to repositories in pom, so that cdap snapshot dependenc...

### DIFF
--- a/MovieRecommender/pom.xml
+++ b/MovieRecommender/pom.xml
@@ -39,9 +39,9 @@
 
   <repositories>
     <repository>
-      <id>oss.sonatype</id>
-      <name>OSS Sonatype Public</name>
-      <url>http://oss.sonatype.org/content/groups/public/</url>
+      <id>oss.sonatype.snapshots</id>
+      <name>OSS Sonatype Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </repository>
     <repository>
       <id>scala-tools.org</id>

--- a/TwitterSentiment/pom.xml
+++ b/TwitterSentiment/pom.xml
@@ -50,6 +50,11 @@
       <id>apache.snapshots</id>
       <url>https://repository.apache.org/content/repositories/snapshots</url>
     </repository>
+    <repository>
+      <id>oss.sonatype.snapshots</id>
+      <name>OSS Sonatype Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
   </repositories>
 
   <dependencies>

--- a/Wise/pom.xml
+++ b/Wise/pom.xml
@@ -24,6 +24,11 @@
       <id>apache.snapshots</id>
       <url>https://repository.apache.org/content/repositories/snapshots</url>
     </repository>
+    <repository>
+      <id>oss.sonatype.snapshots</id>
+      <name>OSS Sonatype Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
   </repositories>
 
   <dependencies>


### PR DESCRIPTION
...ies can be found.

Otherwise, mvn fails if the snapshots are not cached.
