### PR TITLE
Add 2014-2015 copyright to the README file.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Collection of data applications built using `CDAP
 License
 =======
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 


### PR DESCRIPTION
Add 2014-2015 copyright to the README file since the updates happen in 2015 for supporting new version of CDAP.
