### PR TITLE
Fix compilations errors and miscellaneous other cleanup.

### DIFF
--- a/MovieRecommender/src/main/java/co/cask/cdap/apps/movierecommender/MovieDictionaryServiceHandler.java
+++ b/MovieRecommender/src/main/java/co/cask/cdap/apps/movierecommender/MovieDictionaryServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -60,16 +60,16 @@ public class MovieDictionaryServiceHandler extends AbstractHttpServiceHandler {
   }
 
   private boolean parseAndStoreMovies(String moviesData) {
-    boolean validRequest = false;
     String[] lines = NEWLINE_DELIMITER.split(moviesData.trim());
 
     for (String movie : lines) {
       String[] movieInfo = FIELDS_DELIMITER.split(movie.trim());
       if (!movieInfo[0].isEmpty() && !movieInfo[1].isEmpty()) {
-        validRequest = true;
         movies.write(Bytes.toBytes(Integer.parseInt(movieInfo[0])), movieInfo[1]);
+      } else {
+        return false;
       }
     }
-    return validRequest;
+    return true;
   }
 }

--- a/MovieRecommender/src/main/java/co/cask/cdap/apps/movierecommender/MovieRecommenderApp.java
+++ b/MovieRecommender/src/main/java/co/cask/cdap/apps/movierecommender/MovieRecommenderApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,6 @@ import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.dataset.lib.ObjectStores;
-
 
 /**
  * Application that provides movie recommendations to users.

--- a/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/AnalyticsFlow.java
+++ b/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/AnalyticsFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,7 @@
 
 package co.cask.cdap.apps.netlens.app;
 
-import co.cask.cdap.api.flow.Flow;
-import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.AbstractFlow;
 import co.cask.cdap.apps.netlens.app.anomaly.AnomalyDetectionFlowlet;
 import co.cask.cdap.apps.netlens.app.anomaly.AnomalyFanOutFlowlet;
 import co.cask.cdap.apps.netlens.app.anomaly.FactParser;
@@ -28,31 +27,29 @@ import co.cask.cdap.apps.netlens.app.histo.NumberCategorizationFlowlet;
 /**
  *
  */
-public class AnalyticsFlow implements Flow {
+public class AnalyticsFlow extends AbstractFlow {
   static final String NAME = "AnalyticsFlow";
 
   @Override
-  public FlowSpecification configure() {
-    return FlowSpecification.Builder.with()
-      .setName(NAME)
-      .setDescription("Performs analysis of network packets.")
-      .withFlowlets()
-        .add("fact-parser", new FactParser())
-        .add("categorize-numbers", new NumberCategorizationFlowlet())
-        .add("anomaly-fanout", new AnomalyFanOutFlowlet())
-        .add("anomaly-detect", new AnomalyDetectionFlowlet())
-        .add("anomaly-count", new AnomalyCounterFlowlet())
-        .add("traffic-count", new TrafficCounterFlowlet())
-      .connect()
-        .fromStream(NetlensApp.STREAM_NAME).to("fact-parser")
-        // anomaly subtree
-        .from("fact-parser").to("categorize-numbers")
-        .from("categorize-numbers").to("anomaly-fanout")
-        .from("anomaly-fanout").to("anomaly-detect")
-        // anomaly counters
-        .from("anomaly-detect").to("anomaly-count")
-        // counters subtree
-        .from("fact-parser").to("traffic-count")
-      .build();
+  protected void configureFlow() {
+    setName(NAME);
+    setDescription("Performs analysis of network packets.");
+
+    addFlowlet("fact-parser", new FactParser());
+    addFlowlet("categorize-numbers", new NumberCategorizationFlowlet());
+    addFlowlet("anomaly-fanout", new AnomalyFanOutFlowlet());
+    addFlowlet("anomaly-detect", new AnomalyDetectionFlowlet());
+    addFlowlet("anomaly-count", new AnomalyCounterFlowlet());
+    addFlowlet("traffic-count", new TrafficCounterFlowlet());
+
+    connectStream(NetlensApp.STREAM_NAME, "fact-parser");
+    // anomaly subtree
+    connect("fact-parser", "categorize-numbers");
+    connect("categorize-numbers", "anomaly-fanout");
+    connect("anomaly-fanout", "anomaly-detect");
+    // anomaly counters
+    connect("anomaly-detect", "anomaly-count");
+    // counters subtree
+    connect("fact-parser", "traffic-count");
   }
 }

--- a/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/anomaly/AnomaliesServiceHandler.java
+++ b/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/anomaly/AnomaliesServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -65,7 +65,7 @@ public class AnomaliesServiceHandler extends AbstractHttpServiceHandler {
   }
 
   private List<Anomaly> getAnomalies(long endTs, long startTs, String groupFor) {
-    Iterator<TimeseriesTable.Entry> entries = this.anomalies.read(AnomalyDetectionFlowlet.ANOMALY_KEY, startTs, endTs);
+    Iterator<TimeseriesTable.Entry> entries = anomalies.read(AnomalyDetectionFlowlet.ANOMALY_KEY, startTs, endTs);
     if (groupFor == null) {
       return getAnomalies(entries);
     } else {

--- a/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/anomaly/AnomalyDetectionFlowlet.java
+++ b/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/anomaly/AnomalyDetectionFlowlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,6 +26,7 @@ import co.cask.cdap.api.flow.flowlet.FlowletContext;
 import co.cask.cdap.api.flow.flowlet.FlowletException;
 import co.cask.cdap.api.flow.flowlet.OutputEmitter;
 import co.cask.cdap.apps.netlens.app.Constants;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 
@@ -113,6 +114,7 @@ public class AnomalyDetectionFlowlet extends AbstractFlowlet {
     return counters;
   }
 
+  @VisibleForTesting
   static boolean isLastPointAnomaly(int[] counts, double meanThreshold, double sensitivity) {
     // Simple algo: Xn+1 is anomaly if (mean(X1..Xn) - Xn+1) > deviation(X1..Xn) * sensitivity
     double mean = mean(counts, 0, counts.length);

--- a/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/counter/AnomaliesCountServiceHandler.java
+++ b/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/counter/AnomaliesCountServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,6 @@ import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.cdap.apps.netlens.app.Constants;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -43,8 +42,6 @@ import javax.ws.rs.QueryParam;
  * Anomalies count service handler
  */
 public class AnomaliesCountServiceHandler extends AbstractHttpServiceHandler {
-
-  private static final Gson GSON = new Gson();
 
   @UseDataSet("anomalyCounters")
   private TimeseriesTable anomalyCounters;
@@ -116,9 +113,7 @@ public class AnomaliesCountServiceHandler extends AbstractHttpServiceHandler {
 
     // preparing output
     List<DataPoint> dataPoints = Lists.newArrayList();
-    Iterator<Map.Entry<Long, Integer>> it = data.entrySet().iterator();
-    while (it.hasNext()) {
-      Map.Entry<Long, Integer> item = it.next();
+    for (Map.Entry<Long, Integer> item : data.entrySet()) {
       dataPoints.add(new DataPoint(item.getKey(), item.getValue()));
     }
     return dataPoints;

--- a/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/counter/CountersServiceHandler.java
+++ b/Netlens/src/main/java/co/cask/cdap/apps/netlens/app/counter/CountersServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,7 +25,6 @@ import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.cdap.apps.netlens.app.Constants;
 import com.google.common.collect.Lists;
-import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -41,7 +40,6 @@ import javax.ws.rs.QueryParam;
  * Counters service handler
  */
 public class CountersServiceHandler extends AbstractHttpServiceHandler {
-  private static final Gson GSON = new Gson();
 
   @UseDataSet("counters")
   private TimeseriesTable counters;
@@ -76,8 +74,8 @@ public class CountersServiceHandler extends AbstractHttpServiceHandler {
   }
 
   private void getTrafficCounts(long startTs, long endTs, HttpServiceResponder responder) throws IOException {
-    List<DataPoint> counts = CounterTableUtil.getCounts(trafficCounters,
-                                                        Bytes.EMPTY_BYTE_ARRAY, TrafficCounterFlowlet.TOTAL_COUNTER_COLUMN,
+    List<DataPoint> counts = CounterTableUtil.getCounts(trafficCounters, Bytes.EMPTY_BYTE_ARRAY,
+                                                        TrafficCounterFlowlet.TOTAL_COUNTER_COLUMN,
                                                         startTs, endTs);
     responder.sendJson(counts);
   }

--- a/Netlens/src/test/java/co/cask/cdap/apps/netlens/app/NetlensAppTest.java
+++ b/Netlens/src/test/java/co/cask/cdap/apps/netlens/app/NetlensAppTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package co.cask.cdap.apps.netlens.app;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
@@ -6,15 +22,13 @@ import co.cask.cdap.apps.netlens.app.counter.DataPoint;
 import co.cask.cdap.apps.netlens.app.counter.TopNTableUtil;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
-import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
-import com.google.common.collect.Maps;
-import com.google.common.io.ByteStreams;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import org.apache.commons.io.Charsets;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,10 +37,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class NetlensAppTest extends TestBase {
@@ -38,68 +50,46 @@ public class NetlensAppTest extends TestBase {
 
   @Test
   public void testNetlensApp() throws Exception {
-    try {
-      ApplicationManager appManager = deployApplication(NetlensApp.class);
+    ApplicationManager appManager = deployApplication(NetlensApp.class);
 
-      Map<String, String> args = Maps.newHashMap();
-      args.put("disable.public", "true");
+    // Starts a Flow
+    FlowManager flowManager = appManager.getFlowManager(AnalyticsFlow.NAME).start();
 
-      // Starts a Flow
-      FlowManager flowManager = appManager.startFlow(AnalyticsFlow.NAME, args);
+    // Write a message to Stream
+    StreamManager streamWriter = getStreamManager(NetlensApp.STREAM_NAME);
+    sendData(streamWriter);
 
-      try {
-        // Write a message to Stream
-        StreamWriter streamWriter = appManager.getStreamWriter(NetlensApp.STREAM_NAME);
-        sendData(streamWriter);
+    // Wait for the last Flowlet processed all tokens
+    RuntimeMetrics countMetrics = flowManager.getFlowletMetrics("traffic-count");
+    countMetrics.waitForProcessed(1000, 60, TimeUnit.SECONDS);
 
-        // Wait for the last Flowlet processed all tokens
-        RuntimeMetrics countMetrics =
-          RuntimeStats.getFlowletMetrics(NetlensApp.NAME, AnalyticsFlow.NAME, "traffic-count");
-        countMetrics.waitForProcessed(1000, 60, TimeUnit.SECONDS);
-      } finally {
-        flowManager.stop();
-      }
+    ServiceManager anomaliesCountServiceManager =
+      appManager.getServiceManager(NetlensApp.ANOMALIES_COUNT_SERVICE_NAME).start();
+    ServiceManager anomaliesServiceManager = appManager.getServiceManager(NetlensApp.ANOMALIES_SERVICE_NAME).start();
+    ServiceManager countersServiceManager = appManager.getServiceManager(NetlensApp.COUNTERS_SERVICE_NAME).start();
 
-      ServiceManager anomaliesCountServiceManager = appManager.startService(NetlensApp.ANOMALIES_COUNT_SERVICE_NAME);
-      ServiceManager anomaliesServiceManager = appManager.startService(NetlensApp.ANOMALIES_SERVICE_NAME);
-      ServiceManager countersServiceManager = appManager.startService(NetlensApp.COUNTERS_SERVICE_NAME);
+    anomaliesCountServiceManager.waitForStatus(true);
+    anomaliesServiceManager.waitForStatus(true);
+    countersServiceManager.waitForStatus(true);
 
-      anomaliesCountServiceManager.waitForStatus(true);
-      anomaliesServiceManager.waitForStatus(true);
-      countersServiceManager.waitForStatus(true);
-
-      try {
-        testAnomaliesCountService(anomaliesCountServiceManager);
-        testAnomaliesService(anomaliesServiceManager);
-        testCountersService(countersServiceManager);
-      } finally {
-        anomaliesCountServiceManager.stop();
-        anomaliesServiceManager.stop();
-        countersServiceManager.stop();
-
-        anomaliesCountServiceManager.waitForStatus(false);
-        anomaliesServiceManager.waitForStatus(false);
-        countersServiceManager.waitForStatus(false);
-      }
-    } finally {
-      TimeUnit.SECONDS.sleep(1);
-      clear();
-    }
+    testAnomaliesCountService(anomaliesCountServiceManager);
+    testAnomaliesService(anomaliesServiceManager);
+    testCountersService(countersServiceManager);
   }
 
   private void testAnomaliesCountService(ServiceManager serviceManager) throws Exception {
     URL url = new URL(serviceManager.getServiceURL(), String.format("count/%d/%d",
                                                                     START, System.currentTimeMillis()));
-    List<DataPoint> result = GSON.fromJson(doRequest(url), DATA_POINT_LIST_TYPE);
+    List<DataPoint> result = GSON.fromJson(doGet(url), DATA_POINT_LIST_TYPE);
     Assert.assertFalse(result.isEmpty());
 
     url = new URL(serviceManager.getServiceURL(), String.format("uniqueIpsCount/%d/%d",
                                                                 START, System.currentTimeMillis()));
-    result = GSON.fromJson(doRequest(url), DATA_POINT_LIST_TYPE);
+    result = GSON.fromJson(doGet(url), DATA_POINT_LIST_TYPE);
     Assert.assertFalse(result.isEmpty());
 
     url = new URL(serviceManager.getServiceURL(), String.format("topN/%d", START) + "?limit=20");
-    List<TopNTableUtil.TopNResult> topNResults = GSON.fromJson(doRequest(url), TOP_N_RESULT_LIST_TYPE);
+    List<TopNTableUtil.TopNResult> topNResults = GSON.fromJson(doGet(url), TOP_N_RESULT_LIST_TYPE);
     Assert.assertFalse(topNResults.isEmpty());
   }
 
@@ -107,40 +97,33 @@ public class NetlensAppTest extends TestBase {
     URL url = new URL(serviceManager.getServiceURL(), String.format("timeRange/%d/%d?groupFor=none",
                                                                     START, System.currentTimeMillis()));
     List<AnomaliesServiceHandler.Anomaly> result =
-      GSON.fromJson(doRequest(url), new TypeToken<List<AnomaliesServiceHandler.Anomaly>>() {}.getType());
+      GSON.fromJson(doGet(url), new TypeToken<List<AnomaliesServiceHandler.Anomaly>>() {}.getType());
     Assert.assertFalse(result.isEmpty());
   }
 
   private void testCountersService(ServiceManager serviceManager) throws Exception {
     URL url = new URL(serviceManager.getServiceURL(), String.format("counts/%d/%d",
                                                                     START, System.currentTimeMillis()));
-    List<DataPoint> result = GSON.fromJson(doRequest(url), DATA_POINT_LIST_TYPE);
+    List<DataPoint> result = GSON.fromJson(doGet(url), DATA_POINT_LIST_TYPE);
     Assert.assertFalse(result.isEmpty());
 
     url = new URL(serviceManager.getServiceURL(), String.format("topN/%d", START) + "?limit=20");
-    List<TopNTableUtil.TopNResult> topNResults = GSON.fromJson(doRequest(url), TOP_N_RESULT_LIST_TYPE);
+    List<TopNTableUtil.TopNResult> topNResults = GSON.fromJson(doGet(url), TOP_N_RESULT_LIST_TYPE);
     Assert.assertFalse(topNResults.isEmpty());
   }
 
-  private static String doRequest(URL url) throws IOException {
-    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-    String response;
-    try {
-      response = new String(ByteStreams.toByteArray(connection.getInputStream()), Charsets.UTF_8);
-    } finally {
-      connection.disconnect();
-    }
-    return response;
+  private static String doGet(URL url) throws IOException {
+    return HttpRequests.execute(HttpRequest.get(url).build()).getResponseBodyAsString();
   }
 
-  private void sendData(StreamWriter streamWriter) throws IOException {
+  private void sendData(StreamManager streamManager) throws IOException {
     File anomaliesData = new File(System.getProperty("user.dir").concat("/resources/anomalies.data"));
     Thread.currentThread().getContextClassLoader().getResource("anomalies.data");
     FileReader fileReader = new FileReader(anomaliesData);
     BufferedReader reader = new BufferedReader(fileReader);
     String line;
     while ((line = reader.readLine()) != null) {
-      streamWriter.send(line);
+      streamManager.send(line);
     }
   }
 }

--- a/TwitterSentiment/src/main/java/co/cask/cdap/apps/sentiment/SentimentAnalysisFlow.java
+++ b/TwitterSentiment/src/main/java/co/cask/cdap/apps/sentiment/SentimentAnalysisFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,32 +13,28 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.apps.sentiment;
 
-import co.cask.cdap.api.flow.Flow;
-import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.AbstractFlow;
 
 /**
  * Flow for sentiment analysis.
  */
-public class SentimentAnalysisFlow implements Flow {
+public class SentimentAnalysisFlow extends AbstractFlow {
   static final String FLOW_NAME = "TwitterSentimentAnalysis";
-  @Override
-  public FlowSpecification configure() {
-    return FlowSpecification.Builder.with()
-      .setName(FLOW_NAME)
-      .setDescription("Analysis of text to generate sentiments")
-      .withFlowlets()
-        .add(new TweetCollector())
-        .add(new TweetParserFlowlet())
-        .add(new PythonAnalyzer())
-        .add(new CountSentimentFlowlet())
-      .connect()
-        .fromStream(TwitterSentimentApp.STREAM_NAME).to(new TweetParserFlowlet())
-        .from(new TweetParserFlowlet()).to(new PythonAnalyzer())
-        .from(new TweetCollector()).to(new PythonAnalyzer())
-        .from(new PythonAnalyzer()).to(new CountSentimentFlowlet())
-      .build();
-  }
 
+  @Override
+  protected void configureFlow() {
+    setName(FLOW_NAME);
+    setDescription("Analysis of text to generate sentiments");
+    addFlowlet(new TweetCollector());
+    addFlowlet(new TweetParserFlowlet());
+    addFlowlet(new PythonAnalyzer());
+    addFlowlet(new CountSentimentFlowlet());
+    connectStream(TwitterSentimentApp.STREAM_NAME, new TweetParserFlowlet());
+    connect(new TweetParserFlowlet(), new PythonAnalyzer());
+    connect(new TweetCollector(), new PythonAnalyzer());
+    connect(new PythonAnalyzer(), new CountSentimentFlowlet());
+  }
 }

--- a/Wise/src/main/java/co/cask/cdap/apps/wise/BounceCountsMapReduce.java
+++ b/Wise/src/main/java/co/cask/cdap/apps/wise/BounceCountsMapReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -44,11 +44,12 @@ public class BounceCountsMapReduce extends AbstractMapReduce {
   public void configure() {
     setName("BounceCountsMapReduce");
     setDescription("Bounce Counts MapReduce Program");
-    setOutputDataset("bounceCountStore");
   }
 
   @Override
   public void beforeSubmit(MapReduceContext context) throws Exception {
+    context.addOutput("bounceCountStore");
+
     // Retrieve Hadoop Job
     Job job = context.getHadoopJob();
 
@@ -144,7 +145,7 @@ public class BounceCountsMapReduce extends AbstractMapReduce {
         long visitsCount = uriCount.getValue();
         Long bounceCount = uriBounces.get(uri);
         if (bounceCount == null) {
-          bounceCount = new Long(0);
+          bounceCount = 0L;
         }
         context.write(null, new PageBounce(uri, visitsCount, bounceCount));
       }

--- a/Wise/src/main/java/co/cask/cdap/apps/wise/PageViewStore.java
+++ b/Wise/src/main/java/co/cask/cdap/apps/wise/PageViewStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.apps.wise;
 
 import co.cask.cdap.api.common.Bytes;
@@ -78,7 +79,7 @@ public class PageViewStore extends AbstractDataset
    */
   public long getCounts(String ipAddress) {
     Row row = this.table.get(new Get(ipAddress));
-    if (row == null || row.isEmpty()) {
+    if (row.isEmpty()) {
       return 0;
     }
     int count = 0;

--- a/Wise/src/main/java/co/cask/cdap/apps/wise/WiseApp.java
+++ b/Wise/src/main/java/co/cask/cdap/apps/wise/WiseApp.java
@@ -13,11 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.apps.wise;
 
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.internal.schedule.TimeSchedule;
 
 /**
  * The Wise application performs analytics on Apache access logs.
@@ -42,6 +45,7 @@ public class WiseApp extends AbstractApplication {
     // Add the WiseService service
     addService(new WiseService());
     // Schedule the Workflow to run the MapReduce program every ten minutes
-    scheduleWorkflow(new Schedule("TenMinuteSchedule", "Run every 10 minutes", "0/10 * * * *"), "WiseWorkflow");
+    scheduleWorkflow(Schedules.createTimeSchedule("TenMinuteSchedule", "Run every 10 minutes", "0/10 * * * *"),
+                     "WiseWorkflow");
   }
 }

--- a/Wise/src/main/java/co/cask/cdap/apps/wise/WiseWorkflow.java
+++ b/Wise/src/main/java/co/cask/cdap/apps/wise/WiseWorkflow.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.apps.wise;
 
 import co.cask.cdap.api.workflow.AbstractWorkflow;
@@ -25,8 +26,8 @@ public class WiseWorkflow extends AbstractWorkflow {
 
   @Override
   public void configure() {
-      setName("WiseWorkflow");
-      setDescription("Wise Workflow");
-      addMapReduce("BounceCountsMapReduce");
+    setName("WiseWorkflow");
+    setDescription("Wise Workflow");
+    addMapReduce("BounceCountsMapReduce");
   }
 }


### PR DESCRIPTION
The cdap-apps repo had gone outdated. Even though methods were deprecated in a previous release, the relevant code in these apps were not updated.
So, when the deprecated APIs got removed, these apps' test cases no longer compiled.

This Pull Request updates these apps to use the newer APIs and also does additional cleanup.
