### PR TITLE
CDAP-7182 Document using cdap script

### DIFF
--- a/MovieRecommender/README.rst
+++ b/MovieRecommender/README.rst
@@ -112,7 +112,7 @@ To stop the application, execute::
 License
 =======
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at

--- a/MovieRecommender/README.rst
+++ b/MovieRecommender/README.rst
@@ -44,34 +44,34 @@ From the project root, build ``MovieRecommender`` with `Apache Maven <http://mav
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap-cli.sh`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin
 
 If you haven't already started a standalone CDAP installation, start it with the command::
 
-  $ cdap.sh start
+  $ cdap sdk start
 
-On Windows, substitute ``cdap.bat`` for ``cdap.sh``.
+On Windows, substitute ``cdap.bat sdk`` for ``cdap sdk``.
 
 Deploy the Application to a CDAP instance defined by its host (defaults to localhost)::
 
-  $ cdap-cli.sh load artifact target/MovieRecommender-<version>.jar
-  $ cdap-cli.sh create app MovieRecommender MovieRecommender <version> user
+  $ cdap cli load artifact target/MovieRecommender-<version>.jar
+  $ cdap cli create app MovieRecommender MovieRecommender <version> user
   
-On Windows, substitute ``cdap-cli.bat`` for ``cdap-cli.sh``.
+On Windows, substitute ``cdap.bat cli`` for ``cdap cli``.
 
 Start the Application Services::
 
-  $ cdap-cli.sh start service MovieRecommender.MovieDictionaryService
-  $ cdap-cli.sh start service MovieRecommender.MovieRecommenderService
+  $ cdap cli start service MovieRecommender.MovieDictionaryService
+  $ cdap cli start service MovieRecommender.MovieRecommenderService
   
 Make sure that the Services are running (note that the
 ``RecommendationBuilder`` Spark program will be started later)::
 
-  $ cdap-cli.sh get service status MovieRecommender.MovieDictionaryService
-  $ cdap-cli.sh get service status MovieRecommender.MovieRecommenderService
+  $ cdap cli get service status MovieRecommender.MovieDictionaryService
+  $ cdap cli get service status MovieRecommender.MovieRecommenderService
   
 Ingest ``ratings`` and ``movies`` data::
 
@@ -81,16 +81,16 @@ On Windows, substitute ``ingest-data.bat`` for ``ingest-data.sh``.
 
 Run the ``RecommendationBuilder`` Spark Program::
 
-  $ cdap-cli.sh start spark MovieRecommender.RecommendationBuilder
+  $ cdap cli start spark MovieRecommender.RecommendationBuilder
 
 The Spark program may take a couple of minutes to complete. You can check if it is complete by its
 status (once done, it becomes STOPPED)::
 
-  $ cdap-cli.sh get spark status MovieRecommender.RecommendationBuilder
+  $ cdap cli get spark status MovieRecommender.RecommendationBuilder
   
 Once the Spark program is complete, you can query the ``MovieRecommenderService`` for recommendations::
 
-  $ cdap-cli.sh call service MovieRecommender.MovieRecommenderService GET 'recommend/1'
+  $ cdap cli call service MovieRecommender.MovieRecommenderService GET 'recommend/1'
   
 This will return a JSON response of rated and recommended movies::
 
@@ -106,8 +106,8 @@ This will return a JSON response of rated and recommended movies::
 
 To stop the application, execute::
 
-  $ cdap-cli.sh stop service MovieRecommender.MovieDictionaryService
-  $ cdap-cli.sh stop service MovieRecommender.MovieRecommenderService
+  $ cdap cli stop service MovieRecommender.MovieDictionaryService
+  $ cdap cli stop service MovieRecommender.MovieRecommenderService
 
 License
 =======

--- a/MovieRecommender/README.rst
+++ b/MovieRecommender/README.rst
@@ -44,7 +44,7 @@ From the project root, build ``MovieRecommender`` with `Apache Maven <http://mav
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin

--- a/Netlens/README.rst
+++ b/Netlens/README.rst
@@ -79,37 +79,37 @@ From the project root, build ``Netlens`` with `Apache Maven <http://maven.apache
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap-cli.sh`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin
 
 If you haven't already started a standalone CDAP installation, start it with the command::
 
-  $ cdap.sh start
+  $ cdap sdk start
 
-On Windows, substitute ``cdap.bat`` for ``cdap.sh``.
+On Windows, substitute ``cdap.bat sdk`` for ``cdap sdk``.
 
 Deploy the Application to a CDAP instance defined by its host (defaults to ``localhost``)::
   
-  $ cdap-cli.sh load artifact target/Netlens-<version>.jar
-  $ cdap-cli.sh create app Netlens Netlens <version> user
+  $ cdap cli load artifact target/Netlens-<version>.jar
+  $ cdap cli create app Netlens Netlens <version> user
   
-On Windows, substitute ``cdap-cli.bat`` for ``cdap-cli.sh``.
+On Windows, substitute ``cdap.bat cli`` for ``cdap cli``.
 
 Start the Application Flows and Services::
 
-  $ cdap-cli.sh start flow Netlens.AnalyticsFlow 
-  $ cdap-cli.sh start service Netlens.AnomaliesCountService 
-  $ cdap-cli.sh start service Netlens.AnomaliesService 
-  $ cdap-cli.sh start service Netlens.CountersService 
+  $ cdap cli start flow Netlens.AnalyticsFlow 
+  $ cdap cli start service Netlens.AnomaliesCountService 
+  $ cdap cli start service Netlens.AnomaliesService 
+  $ cdap cli start service Netlens.CountersService 
 
 Make sure they are running::
 
-  $ cdap-cli.sh get flow status Netlens.AnalyticsFlow 
-  $ cdap-cli.sh get service status Netlens.AnomaliesCountService 
-  $ cdap-cli.sh get service status Netlens.AnomaliesService 
-  $ cdap-cli.sh get service status Netlens.CountersService 
+  $ cdap cli get flow status Netlens.AnalyticsFlow 
+  $ cdap cli get service status Netlens.AnomaliesCountService 
+  $ cdap cli get service status Netlens.AnomaliesService 
+  $ cdap cli get service status Netlens.CountersService 
 
 Ingest sample traffic data::
 

--- a/Netlens/README.rst
+++ b/Netlens/README.rst
@@ -132,7 +132,7 @@ The Web interface will then be available at ``http://localhost:8080/Netlens``
 License
 =======
 
-Copyright © 2014-2015 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at

--- a/Netlens/README.rst
+++ b/Netlens/README.rst
@@ -79,7 +79,7 @@ From the project root, build ``Netlens`` with `Apache Maven <http://maven.apache
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin

--- a/TwitterSentiment/README.rst
+++ b/TwitterSentiment/README.rst
@@ -61,7 +61,7 @@ From the project root, build ``TwitterSentiment`` with `Apache Maven <http://mav
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin

--- a/TwitterSentiment/README.rst
+++ b/TwitterSentiment/README.rst
@@ -61,33 +61,33 @@ From the project root, build ``TwitterSentiment`` with `Apache Maven <http://mav
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap-cli.sh`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin
 
 If you haven't already started a standalone CDAP installation, start it with the command::
 
-  $ cdap.sh start
+  $ cdap sdk start
 
-On Windows, substitute ``cdap.bat`` for ``cdap.sh``.
+On Windows, substitute ``cdap.bat sdk`` for ``cdap sdk``.
 
 Deploy the Application to a CDAP instance defined by its host (defaults to ``localhost``)::
 
-  $ cdap-cli.sh load artifact target/TwitterSentiment-<version>.jar
-  $ cdap-cli.sh create app TwitterSentiment TwitterSentiment <version> user
+  $ cdap cli load artifact target/TwitterSentiment-<version>.jar
+  $ cdap cli create app TwitterSentiment TwitterSentiment <version> user
 
-On Windows, substitute ``cdap-cli.bat`` for ``cdap-cli.sh``.
+On Windows, substitute ``cdap.bat cli`` for ``cdap cli``.
 
 Start Application Flows and Services::
 
-  $ cdap-cli.sh start flow TwitterSentiment.TwitterSentimentAnalysis
-  $ cdap-cli.sh start service TwitterSentiment.SentimentQuery
+  $ cdap cli start flow TwitterSentiment.TwitterSentimentAnalysis
+  $ cdap cli start service TwitterSentiment.SentimentQuery
 
 Make sure they are running::
 
-  $ cdap-cli.sh get flow status TwitterSentiment.TwitterSentimentAnalysis
-  $ cdap-cli.sh get service status TwitterSentiment.SentimentQuery
+  $ cdap cli get flow status TwitterSentiment.TwitterSentimentAnalysis
+  $ cdap cli get service status TwitterSentiment.SentimentQuery
 
 Ingest sample statements::
 
@@ -106,8 +106,8 @@ Once the Web UI is running, it can be viewed at http://localhost:8080/TwitterSen
 
 Stop Application Flows and Services::
 
-  $ cdap-cli.sh stop flow TwitterSentiment.TwitterSentimentAnalysis
-  $ cdap-cli.sh stop service TwitterSentiment.SentimentQuery
+  $ cdap cli stop flow TwitterSentiment.TwitterSentimentAnalysis
+  $ cdap cli stop service TwitterSentiment.SentimentQuery
 
 Processing Real-time Twitter Data
 =================================

--- a/TwitterSentiment/README.rst
+++ b/TwitterSentiment/README.rst
@@ -156,7 +156,7 @@ These arguments are supported:
 License
 =======
 
-Copyright © 2014-2015 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at

--- a/Wise/README.rst
+++ b/Wise/README.rst
@@ -74,7 +74,7 @@ From the project root, build ``Wise`` with `Apache Maven <http://maven.apache.or
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin

--- a/Wise/README.rst
+++ b/Wise/README.rst
@@ -74,30 +74,30 @@ From the project root, build ``Wise`` with `Apache Maven <http://maven.apache.or
 
   $ MAVEN_OPTS="-Xmx512m" mvn clean package
 
-Note that the remaining commands assume that the ``cdap-cli.sh`` script is available on your PATH.
+Note that the remaining commands assume that the ``cdap cli`` script is available on your PATH.
 If this is not the case, please add it::
 
   $ export PATH=$PATH:<cdap-home>/bin
 
 If you haven't already started a standalone CDAP installation, start it with the command::
 
-  $ cdap.sh start
+  $ cdap sdk start
 
-On Windows, substitute ``cdap.bat`` for ``cdap.sh``.
+On Windows, substitute ``cdap.bat sdk`` for ``cdap sdk``.
 
 Deploy the Application to a CDAP instance defined by its host (defaults to ``localhost``)::
   
-  $ cdap-cli.sh load artifact target/cdap-wise-<version>.jar
-  $ cdap-cli.sh create app Wise cdap-wise <version> user
+  $ cdap cli load artifact target/cdap-wise-<version>.jar
+  $ cdap cli create app Wise cdap-wise <version> user
 
-On Windows, substitute ``cdap-cli.bat`` for ``cdap-cli.sh``.
+On Windows, substitute ``cdap.bat cli`` for ``cdap cli``.
 
 To start the application::
 
-  $ cdap-cli.sh start flow Wise.WiseFlow
-  $ cdap-cli.sh start service Wise.WiseService
+  $ cdap cli start flow Wise.WiseFlow
+  $ cdap cli start service Wise.WiseService
 
-On Windows, substitute ``cdap-cli.bat`` for ``cdap-cli.sh``.
+On Windows, substitute ``cdap.bat cli`` for ``cdap cli``.
 
 You can ingest sample data::
 
@@ -139,11 +139,11 @@ Here are some of the SQL queries that you can run:
 
 - Retrieve the web pages from where IP addresses have bounced more than 10% of the time::
 
-    $ cdap-cli.sh execute "'SELECT uri FROM dataset_bouncecountstore WHERE bounces > 0.1 * totalvisits'"
+    $ cdap cli execute "'SELECT uri FROM dataset_bouncecountstore WHERE bounces > 0.1 * totalvisits'"
 
 - Retrieve all the IP addresses which visited the page '/contact.html'::
 
-    $ cdap-cli.sh execute "'SELECT key FROM dataset_pageviewstore WHERE array_contains(map_keys(value), '/contact.html')=TRUE'"
+    $ cdap cli execute "'SELECT key FROM dataset_pageviewstore WHERE array_contains(map_keys(value), '/contact.html')=TRUE'"
 
 As the SQL engine that CDAP runs internally is Hive, the SQL language used to submit queries is HiveQL.
 A description of it is in the `Hive language manual

--- a/Wise/README.rst
+++ b/Wise/README.rst
@@ -160,7 +160,7 @@ An extensive tutorial, based on the Wise application, is available through
 License
 =======
 
-Copyright © 2014-2015 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at


### PR DESCRIPTION
Updated docs to use the new unified `cdap` scripts.

```
sed -i \
    -e 's#cdap-cli.sh#cdap cli#g' \
    -e 's#cdap.sh#cdap sdk#g' \
    -e 's#cdap.bat#cdap.bat sdk#g' \
    -e 's#cdap-cli.bat#cdap.bat cli#g' \
    */*.rst
```

This assumes that caskdata/cdap#6774 has been merged.
