### PR TITLE
[CDAP-7563] Remove use of deprecated methods from Wise

### DIFF
--- a/Wise/src/main/java/co/cask/cdap/apps/wise/BounceCountsMapReduce.java
+++ b/Wise/src/main/java/co/cask/cdap/apps/wise/BounceCountsMapReduce.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.apps.wise;
 
 import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import com.google.common.collect.Maps;
@@ -50,7 +51,7 @@ public class BounceCountsMapReduce extends AbstractMapReduce {
   public void initialize() throws Exception {
     MapReduceContext context = getContext();    
   
-    context.addOutput("bounceCountStore");
+    context.addOutput(Output.ofDataset("bounceCountStore"));
 
     // Retrieve Hadoop Job
     Job job = context.getHadoopJob();


### PR DESCRIPTION
turns out it was only using one deprecated API. 