### PR TITLE
Remove 'provided' scope for guava dependency.

### DIFF
--- a/MovieRecommender/pom.xml
+++ b/MovieRecommender/pom.xml
@@ -111,7 +111,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-7568

Will cherry-pick this commit directly to the following branches following this PR's merge:
release/cdap-3.4-compatible
release/cdap-3.5-compatible
release/cdap-3.6-compatible
